### PR TITLE
Sync LSP: add typescript-tools setup

### DIFF
--- a/.config/nvim/lua/lsp.lua
+++ b/.config/nvim/lua/lsp.lua
@@ -22,6 +22,8 @@ end
 
 vim.lsp.enable(servers)
 
+require("typescript-tools").setup({})
+
 vim.api.nvim_create_autocmd('LspAttach', {
   callback = function(args)
     local opts = { buffer = args.buf, silent = true }


### PR DESCRIPTION
Add typescript-tools plugin setup to the LSP configuration.

This brings in the typescript-tools plugin setup from the linux branch, providing enhanced TypeScript integration in Neovim.

## Changes
- Added typescript-tools setup to lua/lsp.lua

## Related
Sync from linux branch improvements